### PR TITLE
Add JDK 25 + migrate check workflow to new format

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If the Step fails to set the Java version, you can use these [scripts](https://d
 
 ## 🧩 Get started
 
-Add this step directly to your workflow in the [Bitrise Workflow Editor](https://devcenter.bitrise.io/steps-and-workflows/steps-and-workflows-index/).
+Add this step directly to your workflow in the [Bitrise Workflow Editor](https://docs.bitrise.io/en/bitrise-ci/workflows-and-pipelines/steps/adding-steps-to-a-workflow.html).
 
 You can also run this step directly with [Bitrise CLI](https://github.com/bitrise-io/bitrise).
 
@@ -34,7 +34,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 
 | Key | Description | Flags | Default |
 | --- | --- | --- | --- |
-| `set_java_version` | Select the installed Java version you want to use during the build run. You can check [in system reports](https://stacks.bitrise.io) which Java versions are installed on each Bitrise stack.  | required | `11` |
+| `set_java_version` | Select the installed Java version you want to use during the build run.  You can check [in system reports](https://stacks.bitrise.io) which Java versions are installed on each Bitrise stack.  | required | `11` |
 </details>
 
 <details>
@@ -49,9 +49,8 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 
 We welcome [pull requests](https://github.com/bitrise-steplib/bitrise-step-set-java-version/pulls) and [issues](https://github.com/bitrise-steplib/bitrise-step-set-java-version/issues) against this repository.
 
-For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://devcenter.bitrise.io/bitrise-cli/run-your-first-build/).
+For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://docs.bitrise.io/en/bitrise-ci/bitrise-cli/running-your-first-local-build-with-the-cli.html).
 
 Learn more about developing steps:
 
-- [Create your own step](https://devcenter.bitrise.io/contributors/create-your-own-step/)
-- [Testing your Step](https://devcenter.bitrise.io/contributors/testing-and-versioning-your-steps/)
+- [Create your own step](https://docs.bitrise.io/en/bitrise-ci/workflows-and-pipelines/developing-your-own-bitrise-step/developing-a-new-step.html)

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,10 +1,13 @@
 format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
+include:
+- repository: steps-check
+  branch: master
+  path: steps.bitrise.yml
+
 workflows:
-  check:
-    steps:
-    - git::https://github.com/bitrise-steplib/steps-check.git: { }
+  # check: included from steps-check/steps.bitrise.yml
 
   e2e:
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -61,6 +61,17 @@ workflows:
         inputs:
         - set_java_version: 21
 
+  test_java25:
+    envs:
+    - EXPECTED_VERSION: 25
+    after_run:
+    - _check_version
+    steps:
+    - path::./:
+        title: Execute step
+        inputs:
+        - set_java_version: 25
+
   _check_version:
     summary: Compares current JDK version to $EXPECTED_VERSION
     description: Based on https://stackoverflow.com/a/56243046

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -74,7 +74,7 @@ workflows:
             #!/bin/bash
             set -ex
             # TODO: Remove this guard once osx-xcode stacks ship JDK 25
-            if [[ "$BITRISEIO_STACK_ID" == osx-xcode-* ]]; then
+            if [[ "$BITRISEIO_STACK_ID" == osx-xcode-* ]] || [[ "$BITRISEIO_STACK_ID" == linux-docker-android-22.04 ]]; then
               VERSION_AVAILABLE=false
             else
               VERSION_AVAILABLE=true

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -73,8 +73,8 @@ workflows:
         - content: |-
             #!/bin/bash
             set -ex
-            # TODO: Remove this guard once Xcode 26.0-26.3 stacks ship JDK 25
-            if [[ "$BITRISEIO_STACK_ID" == osx-xcode-26.0.* ]] || [[ "$BITRISEIO_STACK_ID" == osx-xcode-26.1.* ]] || [[ "$BITRISEIO_STACK_ID" == osx-xcode-26.2.* ]] || [[ "$BITRISEIO_STACK_ID" == osx-xcode-26.3.* ]]; then
+            # TODO: Remove this guard once osx-xcode stacks ship JDK 25
+            if [[ "$BITRISEIO_STACK_ID" == osx-xcode-* ]]; then
               VERSION_AVAILABLE=false
             else
               VERSION_AVAILABLE=true

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -73,8 +73,12 @@ workflows:
         - content: |-
             #!/bin/bash
             set -ex
-            # TODO: Remove this guard once stacks ship JDK 25
-            VERSION_AVAILABLE=false
+            # TODO: Remove this guard once osx-xcode stacks ship JDK 25
+            if [[ "$BITRISEIO_STACK_ID" == osx-xcode-* ]]; then
+              VERSION_AVAILABLE=false
+            else
+              VERSION_AVAILABLE=true
+            fi
             envman add --key VERSION_AVAILABLE --value "$VERSION_AVAILABLE"
 
     - path::./:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -14,7 +14,7 @@ workflows:
         - content: |-
             #!/bin/bash
             set -ex
-            if [[ "$BITRISEIO_STACK_ID" == osx-xcode-15.* ]] || [[ "$BITRISEIO_STACK_ID" == osx-xcode-14.* ]] || [[ "$BITRISEIO_STACK_ID" == linux-docker-android-* ]]; then
+            if [[ "$BITRISEIO_STACK_ID" == linux-docker-android-* ]]; then
               VERSION_AVAILABLE=true
             else
               VERSION_AVAILABLE=false

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -73,12 +73,8 @@ workflows:
         - content: |-
             #!/bin/bash
             set -ex
-            # TODO: Remove this guard once osx-xcode stacks ship JDK 25
-            if [[ "$BITRISEIO_STACK_ID" == osx-xcode-* ]]; then
-              VERSION_AVAILABLE=false
-            else
-              VERSION_AVAILABLE=true
-            fi
+            # TODO: Remove this guard once stacks ship JDK 25
+            VERSION_AVAILABLE=false
             envman add --key VERSION_AVAILABLE --value "$VERSION_AVAILABLE"
 
     - path::./:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -67,8 +67,24 @@ workflows:
     after_run:
     - _check_version
     steps:
+    - script:
+        title: Check if JDK version is available on stack
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
+            # TODO: Remove this guard once Xcode 26.0-26.3 stacks ship JDK 25
+            if [[ "$BITRISEIO_STACK_ID" == osx-xcode-26.0.* ]] || [[ "$BITRISEIO_STACK_ID" == osx-xcode-26.1.* ]] || [[ "$BITRISEIO_STACK_ID" == osx-xcode-26.2.* ]] || [[ "$BITRISEIO_STACK_ID" == osx-xcode-26.3.* ]]; then
+              VERSION_AVAILABLE=false
+            else
+              VERSION_AVAILABLE=true
+            fi
+            envman add --key VERSION_AVAILABLE --value "$VERSION_AVAILABLE"
+
     - path::./:
         title: Execute step
+        run_if: >
+          {{ enveq "VERSION_AVAILABLE" "true" }}
         inputs:
         - set_java_version: 25
 

--- a/javasetter/javasetter.go
+++ b/javasetter/javasetter.go
@@ -164,6 +164,9 @@ func (j JavaSetter) setJavaUbuntu(version JavaVersion) (Result, error) {
 	case JavaVersion21:
 		javaHome = "/usr/lib/jvm/java-21-openjdk-amd64"
 		javaPath = filepath.Join(javaHome, "bin/java")
+	case JavaVersion25:
+		javaHome = "/usr/lib/jvm/java-25-openjdk-amd64"
+		javaPath = filepath.Join(javaHome, "bin/java")
 	}
 
 	javacPath := filepath.Join(javaHome, "bin/javac")

--- a/javasetter/javasetter.go
+++ b/javasetter/javasetter.go
@@ -19,6 +19,7 @@ const (
 	JavaVersion11 = JavaVersion("11")
 	JavaVersion17 = JavaVersion("17")
 	JavaVersion21 = JavaVersion("21")
+	JavaVersion25 = JavaVersion("25")
 )
 
 // Platform ...
@@ -125,6 +126,8 @@ func (j JavaSetter) setJavaMac(version JavaVersion) (Result, error) {
 		versions = []string{"17", "17.0"}
 	case JavaVersion21:
 		versions = []string{"21", "21.0"}
+	case JavaVersion25:
+		versions = []string{"25", "25.0"}
 	}
 
 	//

--- a/step.go
+++ b/step.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Input struct {
-	JavaVersion string `env:"set_java_version,opt[21,17,11,8]"`
+	JavaVersion string `env:"set_java_version,opt[25,21,17,11,8]"`
 }
 
 type Config struct {

--- a/step.yml
+++ b/step.yml
@@ -37,6 +37,7 @@ inputs:
       You can check [in system reports](https://stacks.bitrise.io) which Java versions are installed on each Bitrise stack.
     is_required: true
     value_options:
+    - "25"
     - "21"
     - "17"
     - "11"


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *MINOR* [version update](https://semver.org/)

### Context

Adds JDK 25 as a selectable Java version option, and migrates the `check` workflow to the modern Unified CI `include:` format.

### Changes

- `bitrise.yml`: replace inline `check` step with `include:` from `steps-check`
- `javasetter/javasetter.go`: add `JavaVersion25` constant and `setJavaMac` switch case for version `25`/`25.0`
- `step.go`: add `25` to the `opt[...]` env tag
- `step.yml`: add `"25"` to `value_options`
- `README.md`: regenerated to reflect updated `step.yml`

### Investigation details

JDK is the next LTS version and we started installing it on stacks

### Decisions

JDK 25 follows the same version string pattern as JDK 21 (`25` and `25.0` as jenv fallback variants).